### PR TITLE
Setup pylint to run locally

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,9 +5,17 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
     - name: Checkout
       uses: actions/checkout@v4.1.1
-    - name: pre-commit
-      uses: pre-commit/action@v3.0.1
+    - name: Setup Conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        activate-environment: deliberate_practice
+        environment-file: deliberate_practice.yml
+    # Pylint has been unable to run within pre-commit, so run it on it's own.
+    - name: Pylint
+      run: pylint **.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+    autofix_prs: false
+    skip: [pylint]
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -25,11 +29,14 @@ repos:
             - flake8-builtins==2.5.0
             - flake8-pytest-style==2.0.0
             - pep8-naming==0.13.3
--   repo: https://github.com/pycqa/pylint
-    rev: v3.1.0
+-   repo: local
     hooks:
-    -   id: pylint
-        args: ["--rcfile=.pylintrc", "-sn"]
+    - id: pylint
+      name: pylint
+      entry: pylint
+      language: system
+      types: [python]
+      args: ["--rcfile=.pylintrc", "-sn"]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.2
   hooks:

--- a/deliberate_practice.yml
+++ b/deliberate_practice.yml
@@ -4,4 +4,5 @@ dependencies:
   - pip
   - pip:
       - pre_commit==3.7.0
+      - pylint==3.1.0
       - pytest==8.1.1


### PR DESCRIPTION
Despite seeming to mostly work when not run locally, pylint docs suggest running it locally to avoid errors. And since I've now hit those errors, I'll follow the docs.

pre-commit and local pylint don't seem to play nice (pylint wasn't found), so run all pre-commit minus pylint through pre-commit.ci, and then run pylint by itself in the github actions.