### PR TITLE
Update various tooling settings to better work with doc strings.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,2 @@
 [flake8]
-max-line-length = 80
-extend-select = B950
 extend-ignore = E203,E501,E701

--- a/.pylintrc
+++ b/.pylintrc
@@ -431,10 +431,12 @@ disable=raw-checker-failed,
         use-symbolic-message-instead,
         use-implicit-booleaness-not-comparison-to-string,
         use-implicit-booleaness-not-comparison-to-zero,
+        # The following are all handled by Ruff.
         missing-module-docstring,
         missing-function-docstring,
         missing-class-docstring,
         empty-docstring,
+        line-too-long
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,18 +1,29 @@
+line-length = 88
+
 [lint]
 # Enable all `pydocstyle` rules, limiting to those that adhere to the
 # Google convention via `convention = "google"`, below.
-select = ["D"]
+# Add "W" and E501 to have Ruff handle all line length related checks.
+# N818 is a nice small naming check that pylint doesn't have, ensuring
+# exceptions end in Error.
+select = ["D", "W", "E501", "N818"]
+
+# On top of the Google convention, disable:
+# D104: Which requires a doc string for every public package.
+# D417: Which requires documentation for every function parameter.
+# At this time, these don't feel like they add enough value in
+# every case to be worth enforcing.
+ignore = ["D104", "D417"]
+
+[lint.pycodestyle]
+# Follow PEP8 guidelines to make this 72.
+max-doc-length = 72
 
 [lint.pydocstyle]
 convention = "google"
 
 [lint.per-file-ignores]
-# Don't required module comments for test files, as they'ed just generally
-# add no real value.
-# Also allow tests to not have a comment for every public function, that
-# test name and content should generally be enough documentation for most.
-"*_test.py" = ["D100", "D103"]
-
-# On top of the Google convention, disable `D417`, which requires
-# documentation for every function parameter.
-ignore = ["D417"]
+# Let test files ignore the need to document their public
+# modules/classes/functions/methods since they aren't really
+# a public and the documentation generally isn't helpful.
+"*_test.py" = ["D100", "D101", "D102", "D103"]


### PR DESCRIPTION
Also have only Ruff worry about overall line lengths, instead of multiple tools reporting it.