### PR TITLE
Modify prompt_for_choice to return the index of the selected value

### DIFF
--- a/deliberate_practice.py
+++ b/deliberate_practice.py
@@ -24,8 +24,9 @@ def select_run_mode(fetch_input: user_input.FetchInputWithPrompt) -> RunMode:
     )
     all_modes = list(RunMode)
 
-    pick = user_input.prompt_for_choice(fetch_input, prompt, all_modes)
-    return RunMode(pick)
+    picked_index = user_input.prompt_for_choice(fetch_input, prompt, all_modes)
+    picked_mode = all_modes[picked_index]
+    return RunMode(picked_mode)
 
 
 def main(fetch_input: user_input.FetchInputWithPrompt) -> None:

--- a/user_input.py
+++ b/user_input.py
@@ -30,12 +30,14 @@ def _is_valid_pick(user_choice: str, max_choice: int) -> bool:
 
 def prompt_for_choice(
     fetch_input: FetchInputWithPrompt, prompt: str, choices: list[str]
-) -> str:
+) -> int:
     """Prompts the user to pick an option from the list of choices.
 
     Note, since python lists are 0-based, but we want to show the
     choices to users as 1-based, we have to 1 when moving to user land
     and remove 1 when moving back to code interactions.
+
+    Returns the index of the selected item.
 
     Raises:
         NoChoiceMadeError: If the user fails to make a decision due to
@@ -57,7 +59,7 @@ def prompt_for_choice(
         if _is_valid_pick(user_choice, max_choice):
             # Subtract 1 here since the user_choice was 1-based before
             # and now is 0-based.
-            return choices[int(user_choice) - 1]
+            return int(user_choice) - 1
 
         print(
             "\n\nUnclear input, was expecting a value between 1 and "

--- a/user_input_test.py
+++ b/user_input_test.py
@@ -7,36 +7,36 @@ from test_utils import mocks
 class TestPromptUserForChoice:
     basic_prompt = "basic prompt string"
 
-    @pytest.mark.parametrize(("pick", "expected_value"), [(1, "a"), (2, "b"), (3, "c")])
-    def test_valid_choices(self, pick: int, expected_value: str) -> None:
+    @pytest.mark.parametrize("pick", [1, 2, 3])
+    def test_valid_choices(self, pick: int) -> None:
         choices = ["a", "b", "c"]
         input_mock = mocks.MockInput([str(pick)])
         selection = user_input.prompt_for_choice(input_mock, self.basic_prompt, choices)
-        assert selection == expected_value
+        assert selection == pick - 1
 
     def test_valid_choice_only_one_option(self) -> None:
         choices = ["a"]
         input_mock = mocks.MockInput(["1"])
         selection = user_input.prompt_for_choice(input_mock, self.basic_prompt, choices)
-        assert selection == "a"
+        assert selection == 0
 
     def test_valid_choice_after_invalid_str(self) -> None:
         input_mock = mocks.MockInput(["invalid_choice", "1"])
         choices = ["a", "b", "c"]
         selection = user_input.prompt_for_choice(input_mock, self.basic_prompt, choices)
-        assert selection == "a"
+        assert selection == 0
 
     def test_valid_choice_after_invalid_int(self) -> None:
         input_mock = mocks.MockInput(["7", "1"])
         choices = ["a", "b", "c"]
         selection = user_input.prompt_for_choice(input_mock, self.basic_prompt, choices)
-        assert selection == "a"
+        assert selection == 0
 
     def test_valid_choice_after_negative_int(self) -> None:
         input_mock = mocks.MockInput(["-7", "2"])
         choices = ["a", "b", "c"]
         selection = user_input.prompt_for_choice(input_mock, self.basic_prompt, choices)
-        assert selection == "b"
+        assert selection == 1
 
     def test_no_choice_made(self) -> None:
         input_mock = mocks.MockInput([])


### PR DESCRIPTION
This is instead of returning the selected string itself.

While it was a bit easier in one spot if the value was returned, it made this function less useful in other spots. And generally, the index is probably the clearer value to return.