### PR TITLE
Remove unneeded input from test_run_practice_mode test

### DIFF
--- a/deliberate_practice_test.py
+++ b/deliberate_practice_test.py
@@ -49,10 +49,7 @@ def test_run_practice_mode(
     ] * number_of_practice_sets
 
     mock_input = mocks.MockInput(
-        [
-            "1",  # Start Practice Mode.
-        ]
-        + practice_session_inputs
+        practice_session_inputs
         + [
             "N",  # Don't practice any more activities, should return.
         ]


### PR DESCRIPTION
Test doesn't need to specify running in mode 1, it was already there.

So this input was just forcing the code to ask the user to input again after an unclear input.