### PR TITLE
Split prompt out of FetchInputWithPrompt

### DIFF
--- a/deliberate_practice.py
+++ b/deliberate_practice.py
@@ -21,7 +21,7 @@ class RunMode(enum.StrEnum):
     EVALUATION = "Evaluation"
 
 
-def select_run_mode(fetch_input: user_input.FetchInputWithPrompt) -> RunMode:
+def select_run_mode(fetch_input: user_input.FetchInput) -> RunMode:
     """Prompts the user to determine what RunMode to launch."""
     prompt = (
         "Welcome to the Deliberate Practice CLI" + "\n"
@@ -35,7 +35,7 @@ def select_run_mode(fetch_input: user_input.FetchInputWithPrompt) -> RunMode:
 
 
 def run_practice_mode(
-    fetch_input: user_input.FetchInputWithPrompt,
+    fetch_input: user_input.FetchInput,
     activities: routine.Activities,
     practices: results.Practices,
 ) -> int:
@@ -77,7 +77,7 @@ def run_practice_mode(
 
 
 def main(
-    fetch_input: user_input.FetchInputWithPrompt,
+    fetch_input: user_input.FetchInput,
     activities_file: pathlib.Path,
     practices_file: pathlib.Path,
 ) -> None:

--- a/deliberate_practice_test.py
+++ b/deliberate_practice_test.py
@@ -61,7 +61,9 @@ def test_run_practice_mode(
     assert activites_done == number_of_practice_sets
 
 
-def test_main_practice_one_activity(tmp_path: pathlib.Path) -> None:
+def test_main_practice_one_activity(
+    tmp_path: pathlib.Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     activity_file = pathlib.Path(tmp_path, "activities.txt")
     with open(activity_file, "w", encoding="utf-8") as f:
         f.write("practice_activity")
@@ -77,6 +79,30 @@ def test_main_practice_one_activity(tmp_path: pathlib.Path) -> None:
         ]
     )
     deliberate_practice.main(mock_input, activity_file, practices_file)
+
+    expected_output = (
+        "Welcome to the Deliberate Practice CLI\n"
+        "Which mode do you wish to run in?\n"
+        "1) Practice\n"
+        "2) Evaluation\n\n"
+        "Staring Practice Mode\n"
+        "Note: No Practices file found. Starting from an empty state\n"
+        "You currently have 1 activities you can practice.\n"
+        "Do you wish to practice an activity?\n(Y/N)? \n"
+        "The chosen activity is:\n"
+        "\tpractice_activity\n\n"
+        "How did you do on this activity?\n"
+        "1) I wasn’t successful\n"
+        "2) I was ~25% successful\n"
+        "3) I was ~50% successful\n"
+        "4) I was ~75% successful\n"
+        "5) I executed the task flawlessly"
+        "\nKeep up the good work\n\n"
+        "Do you wish to practice an activity?\n(Y/N)? "
+    )
+
+    captured_output = capsys.readouterr().out
+    assert expected_output in captured_output
 
 
 def test_main_evaluation(

--- a/test_utils/mocks.py
+++ b/test_utils/mocks.py
@@ -8,7 +8,7 @@ class MockInput:  # pylint: disable=too-few-public-methods
         """Initialize the instance with inputs to return when called."""
         self.inputs = inputs
 
-    def __call__(self, _prompt: str) -> str:
+    def __call__(self) -> str:
         """Returns the next input string.
 
         Raises:

--- a/user_input.py
+++ b/user_input.py
@@ -9,7 +9,7 @@ import typing
 # Note, ideally this should be a type, but that isn't currently
 # supported by mypy.
 # See https://github.com/python/mypy/issues/15238 for details.
-FetchInputWithPrompt = typing.Callable[[], str]
+FetchInput = typing.Callable[[], str]
 
 
 class NoChoiceMadeError(Exception):
@@ -28,9 +28,7 @@ def _is_valid_pick(user_choice: str, max_choice: int) -> bool:
     return True
 
 
-def prompt_for_choice(
-    fetch_input: FetchInputWithPrompt, prompt: str, choices: list[str]
-) -> int:
+def prompt_for_choice(fetch_input: FetchInput, prompt: str, choices: list[str]) -> int:
     """Prompts the user to pick an option from the list of choices.
 
     Note, since python lists are 0-based, but we want to show the
@@ -69,7 +67,7 @@ def prompt_for_choice(
         continue
 
 
-def prompt_yes_or_no(fetch_input: FetchInputWithPrompt, user_prompt: str) -> bool:
+def prompt_yes_or_no(fetch_input: FetchInput, user_prompt: str) -> bool:
     """Returns True if the users responds positively to the prompt.
 
     If the user responds negatively, return False. An unclear input

--- a/user_input.py
+++ b/user_input.py
@@ -9,7 +9,7 @@ import typing
 # Note, ideally this should be a type, but that isn't currently
 # supported by mypy.
 # See https://github.com/python/mypy/issues/15238 for details.
-FetchInputWithPrompt = typing.Callable[[str], str]
+FetchInputWithPrompt = typing.Callable[[], str]
 
 
 class NoChoiceMadeError(Exception):
@@ -49,10 +49,11 @@ def prompt_for_choice(
         f"{str(index)}) {value}" for index, value in enumerate(choices, 1)
     )
     max_choice = len(choices) + 1
-    complete_user_prompt = prompt + "\n" + choices_with_index + "\n"
+    complete_user_prompt = prompt + "\n" + choices_with_index
     while True:
         try:
-            user_choice = fetch_input(complete_user_prompt)
+            print(complete_user_prompt)
+            user_choice = fetch_input()
         except EOFError as e:
             raise NoChoiceMadeError from e
 
@@ -80,7 +81,8 @@ def prompt_yes_or_no(fetch_input: FetchInputWithPrompt, user_prompt: str) -> boo
     """
     while True:
         try:
-            result = fetch_input(user_prompt + "\n(Y/N)? ")
+            print(user_prompt + "\n(Y/N)? ", end="")
+            result = fetch_input()
         except EOFError as e:
             raise NoChoiceMadeError from e
         if result not in ("y", "Y", "n", "N"):


### PR DESCRIPTION
 When some output was sent through input, it wasn't playing nice with pytest input capture, so just treat it like regular output.

Also add a test for practice mode checking the output.