### PR TITLE
Enable checks for D104, requiring doc strings for public packages

### DIFF
--- a/deliberate_practice_project/__init__.py
+++ b/deliberate_practice_project/__init__.py
@@ -1,0 +1,5 @@
+"""Package for the deliberate practice django project.
+
+This is the high level container that contains the settings and
+configuration for the whole project.
+"""

--- a/ruff.toml
+++ b/ruff.toml
@@ -9,12 +9,11 @@ line-length = 88
 select = ["D", "W", "E501", "N818"]
 
 # On top of the Google convention, disable:
-# D104: Which requires a doc string for every public package.
 # D105: Which required a doc string for every magic method (names that start and end with 2 underscores).
 # D417: Which requires documentation for every function parameter.
 # At this time, these don't feel like they add enough value in
 # every case to be worth enforcing.
-ignore = ["D104", "D105", "D417"]
+ignore = ["D105", "D417"]
 
 [lint.pycodestyle]
 # Follow PEP8 guidelines to make this 72.

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Package for test utils used by deliberate practice."""


### PR DESCRIPTION
With the work on Django starting, this check seems helpful now.