### PR TITLE
Add initial empty deliberate_practice_app

### DIFF
--- a/deliberate_practice_app/__init__.py
+++ b/deliberate_practice_app/__init__.py
@@ -1,0 +1,6 @@
+"""Package for the deliberate project django app.
+
+Currently it's the only app used by the Django project.
+If clear splits become visible in the future, it's likely
+this be be split and renamed.
+"""

--- a/deliberate_practice_app/admin.py
+++ b/deliberate_practice_app/admin.py
@@ -1,0 +1,5 @@
+"""Module of all Django App code related to the admin page.
+
+Any models that should appear on the admin page need
+to be registered here.
+"""

--- a/deliberate_practice_app/apps.py
+++ b/deliberate_practice_app/apps.py
@@ -1,0 +1,14 @@
+"""Package declaring all the App specific settings."""
+
+from django.apps import AppConfig
+
+
+class DeliberatePracticeAppConfig(AppConfig):
+    """DeliberatePracticeAppConfig is the config object App settings.
+
+    All configuration values specific to this application should be
+    located here.
+    """
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "deliberat_practice_app"

--- a/deliberate_practice_app/migrations/__init__.py
+++ b/deliberate_practice_app/migrations/__init__.py
@@ -1,0 +1,1 @@
+"""Package for all the deliberate practice DB migrations."""

--- a/deliberate_practice_app/models/__init__.py
+++ b/deliberate_practice_app/models/__init__.py
@@ -1,0 +1,1 @@
+"""Package for all the deliberate practice models."""

--- a/deliberate_practice_app/views/__init__.py
+++ b/deliberate_practice_app/views/__init__.py
@@ -1,0 +1,1 @@
+"""Package for all the deliberate practice views."""


### PR DESCRIPTION
Since this app will just contain everything, we'll call it deliberate_practice_app for now.

Setting up views and models as packages instead of modules so we can start with separate files instead of having everything in one file for each.