### PR TITLE
Add database folder README

### DIFF
--- a/database/README
+++ b/database/README
@@ -1,0 +1,5 @@
+This README ensures this database folder exists.
+
+If this folder doesn't exist, Django fails under the default configs to create
+an SQLite database in this folder as while it will create the DB, it won't create
+the folder.


### PR DESCRIPTION
This prevents Django from having trouble on a clean build where the SQlite DB doesn't exist, it can create the file, but not the folder.