### PR TITLE
Pass black profile to isort on the command line

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[tool.isort]
-profile = "black"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     hooks:
     - id: isort
       name: isort (python)
+      args: ["--profile", "black"]
 -   repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:

--- a/manage.py
+++ b/manage.py
@@ -14,13 +14,9 @@ def main() -> None:
         "DJANGO_SETTINGS_MODULE", "deliberate_practice_project.settings"
     )
     try:
-        # isort: off
-        # isort and black have a weird disagreement here.
         from django.core.management import (  # pylint: disable=import-outside-toplevel
             execute_from_command_line,
         )
-
-        # isort: on
     except ImportError as exc:
         raise ImportError(
             "Couldn't import Django. Are you sure it's installed and "


### PR DESCRIPTION
For some reason isort.cfg didn't seem to work as expected with pre-commit.