### PR TITLE
Allow Setting ALLOWED_HOST from ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ For more details on how to work with pytest, look at https://docs.pytest.org/en/
 You can build an image with:
 docker build -t <image_name> .
 
-You can run an image with:
+If you only want the instance to be visible on the local machine, you can run an image with:
 docker run -p 127.0.0.1:8181:8181 <image_name>
+
+If you only want the instance to be visible to other machines, you can run an image with:
+docker run -p 8181:8181 <image_name>
+
+If you want to change the ALLOWED_HOST value, put the comma seperated values into the DELIBERATE_PRACTICE_SERVER_NAMES environment variable.
 
 Note, by default the docker image uses port 8181.

--- a/deliberate_practice_project/settings.py
+++ b/deliberate_practice_project/settings.py
@@ -9,6 +9,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -24,8 +25,8 @@ SECRET_KEY = "django-insecure-nm3q9bi1*e_ie8z&1d05rtzg)=ko+j6ht@4_4w%43ykbazt_b7
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS: list[str] = []
-
+ALLOWED_HOSTS_ENV = os.environ.get("DELIBERATE_PRACTICE_SERVER_NAMES")
+ALLOWED_HOSTS: list[str] = ALLOWED_HOSTS_ENV.split(",") if ALLOWED_HOSTS_ENV else []
 
 # Application definition
 


### PR DESCRIPTION
DELIBERATE_PRACTICE_SERVER_NAMES can be set to specify what the allowed host are.

If unset, it'll keep the default values like before.