### PR TITLE
Add database/ as a volume to docker compose

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -14,3 +14,6 @@ services:
         required: true
       - path: "./user.env"
         required: false
+    volumes:
+      # Mount the sqlite3 database so it will persist between compose ups and downs.
+      - .\database\:/database/


### PR DESCRIPTION
This ensure the database used is the one that persists on disk, instead of one with the lifetime of the docker image.