### PR TITLE
Allow Changing the App Port through DELIBERATE_PRACTICE_PORT

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,9 @@ services:
     build: .
     restart: unless-stopped
     ports:
-      - "8181:8181"
+      # Default to port 8181 but allow it to be overridden by setting
+      # DELIBERATE_PRACTICE_PORT as an environment variable.
+      - "${DELIBERATE_PRACTICE_PORT:-8181}:8181"
     develop:
       watch:
         - action: sync


### PR DESCRIPTION
By default, the app will serve on port 8181, but this can be overridden by setting DELIBERATE_PRACTICE_PORT to the desired value.